### PR TITLE
fix: Add support for parameterless ops

### DIFF
--- a/test/test_files/yaml/parameterless.yml
+++ b/test/test_files/yaml/parameterless.yml
@@ -1,0 +1,23 @@
+openapi: 3.0.0
+info:
+  title: Parameterless API
+  version: 1.0.0
+  description: API with parameterless endpoints
+servers:
+  - url: https://api.example.com
+paths:
+  /status:
+    get:
+      operationId: getBatchStatus
+      description: Get the status of all batch jobs
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum: [idle, processing, completed]

--- a/test/test_openapi_client_live_openai.py
+++ b/test/test_openapi_client_live_openai.py
@@ -104,7 +104,7 @@ class TestClientLiveOpenAPI:
         """
         from openapi_llm.utils import HttpClientError
 
-        openapi_spec_url = "https://raw.githubusercontent.com/mendableai/firecrawl/main/apps/api/openapi.json"
+        openapi_spec_url = "https://raw.githubusercontent.com/mendableai/firecrawl/main/apps/api/v1-openapi.json"
         config = ClientConfig(openapi_spec=create_openapi_spec(openapi_spec_url), credentials=os.getenv("FIRECRAWL_API_KEY"))
         client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
         response = client.chat.completions.create(

--- a/test/test_openapi_cohere_conversion.py
+++ b/test/test_openapi_cohere_conversion.py
@@ -163,3 +163,13 @@ class TestOpenAPISchemaConversion:
                 "required": True,
             },
         }
+
+    def test_parameterless(self, test_files_path):
+        spec = OpenAPISpecification.from_file(test_files_path / "yaml" / "parameterless.yml")
+        functions = cohere_converter(schema=spec)
+        assert functions
+        assert len(functions) == 1
+        function = functions[0]
+        assert function["name"] == "getBatchStatus"
+        assert function["description"] == "Get the status of all batch jobs"
+        assert function["parameter_definitions"] == {}

--- a/test/test_openapi_openai_conversion.py
+++ b/test/test_openapi_openai_conversion.py
@@ -104,3 +104,19 @@ class TestOpenAPISchemaConversion:
                 "required": ["transaction_amount", "description", "payment_method_id", "payer"],
             }
         )
+
+    @pytest.mark.parametrize("provider", ["openai", "anthropic"])
+    def test_parameterless(self, test_files_path, provider: str):
+        spec = OpenAPISpecification.from_file(test_files_path / "yaml" / "parameterless.yml")
+        functions = openai_converter(schema=spec) if provider == "openai" else anthropic_converter(schema=spec)
+        assert functions
+        assert len(functions) == 1
+        function = functions[0]["function"] if provider == "openai" else functions[0]
+        assert function["name"] == "getBatchStatus"
+        assert function["description"] == "Get the status of all batch jobs"
+        assert (
+            function["parameters"]
+            if provider == "openai"
+            else function["input_schema"]
+            == {"type": "object", "properties": {}}
+        )


### PR DESCRIPTION
### Why:
Enhances the `_convert_operation_to_openai_schema` function to correctly handle OpenAPI specifications that lack parameters, ensuring valid schema returns even when no parameters are present.

- fixes https://github.com/vblagoje/openapi-llm/issues/10

### What:
- Modified `_convert_operation_to_openai_schema` to handle parameterless specifications by implementing a fall-back schema creation mechanism.
- Added a new YAML file `parameterless.yml` to test parameterless OpenAPI schema scenarios.
- Updated existing tests and added new test cases to validate the handling of parameterless API specifications.

### How can it be used:
- Internal change not visible to users

This ensures the function outputs a valid schema when processing specs without parameters.

### How did you test it:
Test cases were added to verify proper conversion of parameterless OpenAPI specifications. The new tests validate that functions are correctly extracted and described, even in the absence of parameters.

### Notes for the reviewer:
Ensure to check that the revamped `_convert_operation_to_openai_schema` consistently handles edge cases related to missing parameters, and that other functionalities remain intact. Pay attention to the additional test coverage introduced via `parameterless.yml`.