### PR TITLE
fix: Minor security schema fix

### DIFF
--- a/openapi_llm/client/config.py
+++ b/openapi_llm/client/config.py
@@ -59,7 +59,7 @@ class ClientConfig:
         :raises ValueError: If the credentials type is not supported.
         """
         security_schemes = self.openapi_spec.get_security_schemes()
-        if not self.credentials:
+        if not self.credentials or not security_schemes:
             return lambda security_scheme, request: None  # No-op function
         if isinstance(self.credentials, str):
             return self._create_authenticator_from_credentials(

--- a/test/test_openapi_client_live_openai.py
+++ b/test/test_openapi_client_live_openai.py
@@ -85,6 +85,28 @@ class TestClientLiveOpenAPI:
         service_response = service_api.invoke(response)
         assert "deepset" in str(service_response)
 
+
+    @pytest.mark.skipif(not os.environ.get("OPENAI_API_KEY", ""), reason="OPENAI_API_KEY not set or empty")
+    @pytest.mark.integration
+    def test_github_json_spec(self):
+        service_api = OpenAPIClient.from_spec(
+            openapi_spec="https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json",
+            allowed_operations=["search/repos"]
+        )
+        client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+        response = client.chat.completions.create(
+            model="gpt-4o",
+            messages=[
+                {
+                    "role": "user",
+                    "content": "Invoke search/repos tool with query 'deepset-ai' and 'haystack'",
+                }
+            ],
+            tools=service_api.tool_definitions,
+        )
+        service_response = service_api.invoke(response)
+        assert "deepset" in str(service_response)
+
     @pytest.mark.skipif(not os.environ.get("FIRECRAWL_API_KEY", ""), reason="FIRECRAWL_API_KEY not set or empty")
     @pytest.mark.skipif(not os.environ.get("OPENAI_API_KEY", ""), reason="OPENAI_API_KEY not set or empty")
     @pytest.mark.integration


### PR DESCRIPTION
### Why:
Enhances the OpenAPI client by ensuring it handles cases where security schemes are not specified, preventing potential issues with missing credentials.

### What:
- Modified the credential handling logic to return a no-op function when security schemes are absent.
- Added integration test to verify API invocation handling with a real OpenAPI specification.

### How can it be used:
The changes allow safer API client initialization in scenarios where `security_schemes` could be undefined:

```python
if not self.credentials or not security_schemes:
    return lambda security_scheme, request: None  # No-op function
```

### How did you test it:
Implemented an integration test that checks the client's functionality with an actual OpenAPI spec from GitHub's REST API. This includes invoking the API and validating responses.

### Notes for the reviewer:
Pay attention to the logic change in `get_authenticator` to ensure no unintentional behaviors are introduced when `security_schemes` is not present. The new test depends on the availability of an API key in the environment to run.